### PR TITLE
Refactor mutatingWebhook to disallow nonsensical states

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ server :: Server API
 server = mutate
 
 mutate :: W.AdmissionReviewRequest -> Handler W.AdmissionReviewResponse
-mutate req = pure $ W.mutatingWebhook req (\_ -> Right W.Allowed) addToleration
+mutate req = pure $ W.mutatingWebhook req (\_ -> Right addToleration)
 
 addToleration :: W.Patch
 addToleration = 


### PR DESCRIPTION
As discussed, change mutatingWebhook to:

1.  Disallow having a patch and an error status at the same time
1.  Make it straightforward to allow patch result to be created based on information in the request